### PR TITLE
walkingkooka 2f83b92f7b9cff43f6b5359dd7fbfc6202ade410 20190809

### DIFF
--- a/src/test/java/walkingkooka/color/AlphaHslColorTest.java
+++ b/src/test/java/walkingkooka/color/AlphaHslColorTest.java
@@ -56,7 +56,7 @@ public final class AlphaHslColorTest extends HslColorTestCase<AlphaHslColor> {
 
     @Test
     public void testParse() {
-        this.parseAndCheck("hsla(359,100%,50%,25%)",
+        this.parseStringAndCheck("hsla(359,100%,50%,25%)",
                 AlphaHslColor.withAlpha(HslColorComponent.hue(359),
                         HslColorComponent.saturation(1.0f),
                         HslColorComponent.lightness(0.5f),
@@ -100,7 +100,7 @@ public final class AlphaHslColorTest extends HslColorTestCase<AlphaHslColor> {
     // ParseStringTesting .............................................................................................
 
     @Override
-    public AlphaHslColor parse(final String text) {
+    public AlphaHslColor parseString(final String text) {
         return Cast.to(HslColor.parseHsl(text));
     }
 }

--- a/src/test/java/walkingkooka/color/AlphaHsvColorTest.java
+++ b/src/test/java/walkingkooka/color/AlphaHsvColorTest.java
@@ -56,7 +56,7 @@ public final class AlphaHsvColorTest extends HsvTestCase<AlphaHsvColor> {
 
     @Test
     public void testParse() {
-        this.parseAndCheck("hsva(359,100%,50%,25%)",
+        this.parseStringAndCheck("hsva(359,100%,50%,25%)",
                 AlphaHsvColor.withAlpha(HsvColorComponent.hue(359),
                         HsvColorComponent.saturation(1.0f),
                         HsvColorComponent.value(0.5f),
@@ -100,7 +100,7 @@ public final class AlphaHsvColorTest extends HsvTestCase<AlphaHsvColor> {
     // ParseStringTesting .............................................................................................
 
     @Override
-    public AlphaHsvColor parse(final String text) {
+    public AlphaHsvColor parseString(final String text) {
         return Cast.to(HsvColor.parseHsv(text));
     }
 }

--- a/src/test/java/walkingkooka/color/ColorTest.java
+++ b/src/test/java/walkingkooka/color/ColorTest.java
@@ -33,12 +33,12 @@ public final class ColorTest implements ClassTesting2<Color>,
 
     @Test
     public void testParseFails() {
-        this.parseFails("abc", IllegalArgumentException.class);
+        this.parseStringFails("abc", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseHsl() {
-        this.parseAndCheck("hsl(359, 0%, 25%)",
+        this.parseStringAndCheck("hsl(359, 0%, 25%)",
                 walkingkooka.color.HslColor.with(walkingkooka.color.HslColorComponent.hue(359f),
                         walkingkooka.color.HslColorComponent.saturation(0.0f),
                         walkingkooka.color.HslColorComponent.lightness(0.25f)));
@@ -46,7 +46,7 @@ public final class ColorTest implements ClassTesting2<Color>,
 
     @Test
     public void testParseHsla() {
-        this.parseAndCheck("hsla(359, 0%, 25%, 50%)",
+        this.parseStringAndCheck("hsla(359, 0%, 25%, 50%)",
                 walkingkooka.color.HslColor.with(walkingkooka.color.HslColorComponent.hue(359f),
                         walkingkooka.color.HslColorComponent.saturation(0.0f),
                         walkingkooka.color.HslColorComponent.lightness(0.25f))
@@ -55,7 +55,7 @@ public final class ColorTest implements ClassTesting2<Color>,
 
     @Test
     public void testParseHsv() {
-        this.parseAndCheck("hsv(359, 0%, 25%)",
+        this.parseStringAndCheck("hsv(359, 0%, 25%)",
                 walkingkooka.color.HsvColor.with(walkingkooka.color.HsvColorComponent.hue(359f),
                         walkingkooka.color.HsvColorComponent.saturation(0.0f),
                         walkingkooka.color.HsvColorComponent.value(0.25f)));
@@ -63,7 +63,7 @@ public final class ColorTest implements ClassTesting2<Color>,
 
     @Test
     public void testParseRgb() {
-        this.parseAndCheck("rgb(12,34,56)",
+        this.parseStringAndCheck("rgb(12,34,56)",
                 walkingkooka.color.RgbColor.with(walkingkooka.color.RgbColorComponent.red((byte) 12),
                         walkingkooka.color.RgbColorComponent.green((byte) 34),
                         walkingkooka.color.RgbColorComponent.blue((byte) 56)));
@@ -117,17 +117,17 @@ public final class ColorTest implements ClassTesting2<Color>,
     // ParseStringTesting...............................................................................................
 
     @Override
-    public Color parse(final String text) {
-        return walkingkooka.color.Color.parse(text);
+    public Color parseString(final String text) {
+        return Color.parse(text);
     }
 
     @Override
-    public Class<? extends RuntimeException> parseFailedExpected(final Class<? extends RuntimeException> expected) {
+    public Class<? extends RuntimeException> parseStringFailedExpected(final Class<? extends RuntimeException> expected) {
         return expected;
     }
 
     @Override
-    public RuntimeException parseFailedExpected(final RuntimeException expected) {
+    public RuntimeException parseStringFailedExpected(final RuntimeException expected) {
         return expected;
     }
 

--- a/src/test/java/walkingkooka/color/ColorTestCase.java
+++ b/src/test/java/walkingkooka/color/ColorTestCase.java
@@ -127,11 +127,11 @@ public abstract class ColorTestCase<C extends Color> implements ClassTesting2<C>
 
     // ParseStringTesting .............................................................................................
 
-    public final RuntimeException parseFailedExpected(final RuntimeException expected) {
+    public final RuntimeException parseStringFailedExpected(final RuntimeException expected) {
         return expected;
     }
 
-    public final Class<? extends RuntimeException> parseFailedExpected(final Class<? extends RuntimeException> expected) {
+    public final Class<? extends RuntimeException> parseStringFailedExpected(final Class<? extends RuntimeException> expected) {
         return expected;
     }
 

--- a/src/test/java/walkingkooka/color/HslColorTest.java
+++ b/src/test/java/walkingkooka/color/HslColorTest.java
@@ -232,7 +232,7 @@ public final class HslColorTest extends ColorTestCase<HslColor> implements Parse
 
     @Test
     public void testParse() {
-        this.parseAndCheck("hsl(359,100%,50%)",
+        this.parseStringAndCheck("hsl(359,100%,50%)",
                 HslColor.with(HslColorComponent.hue(359),
                         HslColorComponent.saturation(1.0f),
                         HslColorComponent.lightness(0.5f)));
@@ -279,7 +279,7 @@ public final class HslColorTest extends ColorTestCase<HslColor> implements Parse
     // ParseStringTesting .............................................................................................
 
     @Override
-    public HslColor parse(final String text) {
+    public HslColor parseString(final String text) {
         return HslColor.parseHsl(text);
     }
 }

--- a/src/test/java/walkingkooka/color/HsvColorTest.java
+++ b/src/test/java/walkingkooka/color/HsvColorTest.java
@@ -232,7 +232,7 @@ public final class HsvColorTest extends ColorTestCase<HsvColor> implements Parse
 
     @Test
     public void testParse() {
-        this.parseAndCheck("hsv(359,100%,50%)",
+        this.parseStringAndCheck("hsv(359,100%,50%)",
                 HsvColor.with(HsvColorComponent.hue(359),
                         HsvColorComponent.saturation(1.0f),
                         HsvColorComponent.value(0.5f)));
@@ -279,7 +279,7 @@ public final class HsvColorTest extends ColorTestCase<HsvColor> implements Parse
     // ParseStringTesting .............................................................................................
 
     @Override
-    public HsvColor parse(final String text) {
+    public HsvColor parseString(final String text) {
         return HsvColor.parseHsv(text);
     }
 }

--- a/src/test/java/walkingkooka/color/OpaqueHslColorTest.java
+++ b/src/test/java/walkingkooka/color/OpaqueHslColorTest.java
@@ -73,7 +73,7 @@ public final class OpaqueHslColorTest extends HslColorTestCase<OpaqueHslColor> {
 
     @Test
     public void testParse() {
-        this.parseAndCheck("hsl(359,100%,50%)",
+        this.parseStringAndCheck("hsl(359,100%,50%)",
                 OpaqueHslColor.withOpaque(HslColorComponent.hue(359),
                         HslColorComponent.saturation(1.0f),
                         HslColorComponent.lightness(0.5f)));
@@ -111,7 +111,7 @@ public final class OpaqueHslColorTest extends HslColorTestCase<OpaqueHslColor> {
     // ParseStringTesting .............................................................................................
 
     @Override
-    public OpaqueHslColor parse(final String text) {
+    public OpaqueHslColor parseString(final String text) {
         return Cast.to(HslColor.parseHsl(text));
     }
 }

--- a/src/test/java/walkingkooka/color/OpaqueHsvColorTest.java
+++ b/src/test/java/walkingkooka/color/OpaqueHsvColorTest.java
@@ -73,7 +73,7 @@ public final class OpaqueHsvColorTest extends HsvTestCase<OpaqueHsvColor> {
 
     @Test
     public void testParse() {
-        this.parseAndCheck("hsv(359,100%,50%)",
+        this.parseStringAndCheck("hsv(359,100%,50%)",
                 OpaqueHsvColor.withOpaque(HsvColorComponent.hue(359),
                         HsvColorComponent.saturation(1.0f),
                         HsvColorComponent.value(0.5f)));
@@ -111,7 +111,7 @@ public final class OpaqueHsvColorTest extends HsvTestCase<OpaqueHsvColor> {
     // ParseStringTesting .............................................................................................
 
     @Override
-    public OpaqueHsvColor parse(final String text) {
+    public OpaqueHsvColor parseString(final String text) {
         return Cast.to(HsvColor.parseHsv(text));
     }
 }

--- a/src/test/java/walkingkooka/color/RgbColorTest.java
+++ b/src/test/java/walkingkooka/color/RgbColorTest.java
@@ -28,49 +28,49 @@ public final class RgbColorTest extends ColorTestCase<RgbColor> implements Parse
 
     @Test
     public void testParseColorMissingLeadingHashFails() {
-        this.parseFails("123", IllegalArgumentException.class);
+        this.parseStringFails("123", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseColorInvalidFails() {
-        this.parseFails("xyz", IllegalArgumentException.class);
+        this.parseStringFails("xyz", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseColorInvalidFails2() {
-        this.parseFails("#1x3", IllegalArgumentException.class);
+        this.parseStringFails("#1x3", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseColorOneDigitFails() {
-        this.parseFails("#1", IllegalArgumentException.class);
+        this.parseStringFails("#1", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseColorTwoDigitsFails() {
-        this.parseFails("#12", IllegalArgumentException.class);
+        this.parseStringFails("#12", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseColorFiveDigitsFails() {
-        this.parseFails("#12345", IllegalArgumentException.class);
+        this.parseStringFails("#12345", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseColorSevenDigitsFails() {
-        this.parseFails("#1234567", IllegalArgumentException.class);
+        this.parseStringFails("#1234567", IllegalArgumentException.class);
     }
 
     // rgba(1,2,3).......................................................................................................
 
     @Test
     public void testParseColorRgbaFunctionIncompleteFails() {
-        this.parseFails("rgba(1", IllegalArgumentException.class);
+        this.parseStringFails("rgba(1", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseColorRgbaFunctionMissingParensRightFails() {
-        this.parseFails("rgba(1,2,3,0.5", IllegalArgumentException.class);
+        this.parseStringFails("rgba(1,2,3,0.5", IllegalArgumentException.class);
     }
 
     @Test
@@ -108,7 +108,7 @@ public final class RgbColorTest extends ColorTestCase<RgbColor> implements Parse
                                     final int green,
                                     final int blue,
                                     final int alpha) {
-        this.parseAndCheck(text,
+        this.parseStringAndCheck(text,
                 RgbColor.with(RedRgbColorComponent.with((byte) red),
                         GreenRgbColorComponent.with((byte) green),
                         BlueRgbColorComponent.with((byte) blue))
@@ -119,12 +119,12 @@ public final class RgbColorTest extends ColorTestCase<RgbColor> implements Parse
 
     @Test
     public void testParseColorRgbFunctionIncompleteFails() {
-        this.parseFails("rgb(1", IllegalArgumentException.class);
+        this.parseStringFails("rgb(1", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseColorRgbFunctionMissingParensRightFails() {
-        this.parseFails("rgb(1,2,3", IllegalArgumentException.class);
+        this.parseStringFails("rgb(1,2,3", IllegalArgumentException.class);
     }
 
     @Test
@@ -148,7 +148,7 @@ public final class RgbColorTest extends ColorTestCase<RgbColor> implements Parse
     }
 
     private void parseRgbAndCheck2(final String text, final int red, final int green, final int blue) {
-        this.parseAndCheck(text, RgbColor.with(RedRgbColorComponent.with((byte) red),
+        this.parseStringAndCheck(text, RgbColor.with(RedRgbColorComponent.with((byte) red),
                 GreenRgbColorComponent.with((byte) green),
                 BlueRgbColorComponent.with((byte) blue)));
     }
@@ -193,7 +193,7 @@ public final class RgbColorTest extends ColorTestCase<RgbColor> implements Parse
     }
 
     private void parseRgbAndCheck(final String text, final int rgb) {
-        this.parseAndCheck(text, RgbColor.fromRgb0(rgb));
+        this.parseStringAndCheck(text, RgbColor.fromRgb0(rgb));
     }
 
     // #1234.............................................................................................................
@@ -266,24 +266,24 @@ public final class RgbColorTest extends ColorTestCase<RgbColor> implements Parse
     }
 
     private void parseArgbAndCheck(final String text, final int argb) {
-        this.parseAndCheck(text, RgbColor.fromArgb0(argb));
+        this.parseStringAndCheck(text, RgbColor.fromArgb0(argb));
     }
 
     // name............................................................................................................
 
     @Test
     public void testParseColorNameUnknownFails() {
-        this.parseFails("Unknown", IllegalArgumentException.class);
+        this.parseStringFails("Unknown", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseColorBlack() {
-        this.parseAndCheck("black", RgbColor.BLACK);
+        this.parseStringAndCheck("black", RgbColor.BLACK);
     }
 
     @Test
     public void testParseColorCyan() {
-        this.parseAndCheck("CYAN", WebColorName.CYAN.color());
+        this.parseStringAndCheck("CYAN", WebColorName.CYAN.color());
     }
 
     @Override
@@ -315,7 +315,7 @@ public final class RgbColorTest extends ColorTestCase<RgbColor> implements Parse
     // ParseStringTesting .............................................................................................
 
     @Override
-    public RgbColor parse(final String text) {
+    public RgbColor parseString(final String text) {
         return RgbColor.parseRgb(text);
     }
 }


### PR DESCRIPTION
- https://github.com/mP1/walkingkooka/pull/2087
- ParseStringTesting method names changes avoid ParserTesting clashes