### PR TITLE
RgbColor.toString 3 or 4 hex digits

### DIFF
--- a/src/main/java/walkingkooka/color/AlphaRgbColor.java
+++ b/src/main/java/walkingkooka/color/AlphaRgbColor.java
@@ -153,14 +153,24 @@ final class AlphaRgbColor extends RgbColor {
         return 8;
     }
 
-    // Object..........................................................................................................
-
-    // UsesToStringBuilder
+    // UsesToStringBuilder..............................................................................................
 
     @Override
     void buildColorComponentsToString(final ToStringBuilder builder) {
-        this.addRedGreenBlueComponents(builder);
-        builder.value(this.alpha);
+        final RedRgbColorComponent red = this.red;
+        final GreenRgbColorComponent green = this.green;
+        final BlueRgbColorComponent blue = this.blue;
+        final AlphaRgbColorComponent alpha = this.alpha;
+
+        if (canBeOneHexDigit(red) && canBeOneHexDigit(green) && canBeOneHexDigit(blue) && canBeOneHexDigit(alpha)) {
+            addHexDigit(red, builder);
+            addHexDigit(green, builder);
+            addHexDigit(blue, builder);
+            addHexDigit(alpha, builder);
+        } else {
+            this.addRedGreenBlueComponents(builder);
+            builder.value(this.alpha);
+        }
     }
 
     // RgbColorString................................................................................

--- a/src/main/java/walkingkooka/color/OpaqueRgbColor.java
+++ b/src/main/java/walkingkooka/color/OpaqueRgbColor.java
@@ -157,13 +157,21 @@ final class OpaqueRgbColor extends RgbColor {
         return 6;
     }
 
-    // Object..........................................................................................................
-
-    // UsesToStringBuilder
+    // UsesToStringBuilder..............................................................................................
 
     @Override
     void buildColorComponentsToString(final ToStringBuilder builder) {
-        this.addRedGreenBlueComponents(builder);
+        final RedRgbColorComponent red = this.red;
+        final GreenRgbColorComponent green = this.green;
+        final BlueRgbColorComponent blue = this.blue;
+
+        if (canBeOneHexDigit(red) && canBeOneHexDigit(green) && canBeOneHexDigit(blue)) {
+            addHexDigit(red, builder);
+            addHexDigit(green, builder);
+            addHexDigit(blue, builder);
+        } else {
+            this.addRedGreenBlueComponents(builder);
+        }
     }
 
     // RgbColorString................................................................................

--- a/src/main/java/walkingkooka/color/RgbColor.java
+++ b/src/main/java/walkingkooka/color/RgbColor.java
@@ -734,6 +734,26 @@ abstract public class RgbColor extends Color implements ColorLike<Integer> {
         builder.value(this.blue);
     }
 
+    final void addHexDigit(final RgbColorComponent component,
+                           final ToStringBuilder builder) {
+        builder.value(
+            Integer.toHexString(
+                component.value & 0xf
+            )
+        );
+    }
+
+    /**
+     * Helper that can be used to format RGB values like #112233 as #123.
+     */
+    static boolean canBeOneHexDigit(final RgbColorComponent component) {
+        final int value = component.value();
+        final int tens = (value >> 4) & 0x0f;
+        final int ones = value & 0x0f;
+
+        return ones == tens;
+    }
+
     // RgbColorString...................................................................................................
 
     /**

--- a/src/test/java/walkingkooka/color/AlphaRgbColorTest.java
+++ b/src/test/java/walkingkooka/color/AlphaRgbColorTest.java
@@ -265,8 +265,24 @@ public final class AlphaRgbColorTest extends RgbColorTestCase<AlphaRgbColor> {
     @Test
     public void testToString() {
         this.toStringAndCheck(
-            RgbColor.fromArgb0(0x04010203),
-            "#01020304"
+            RgbColor.fromArgb0(0x05010234),
+            "#01023405"
+        );
+    }
+
+    @Test
+    public void testToString2() {
+        this.toStringAndCheck(
+            RgbColor.fromArgb0(0x45010203),
+            "#01020345"
+        );
+    }
+
+    @Test
+    public void testToString4HexDigits() {
+        this.toStringAndCheck(
+            RgbColor.fromArgb0(0xee112233),
+            "#123e"
         );
     }
 

--- a/src/test/java/walkingkooka/color/OpaqueRgbColorTest.java
+++ b/src/test/java/walkingkooka/color/OpaqueRgbColorTest.java
@@ -274,6 +274,22 @@ public final class OpaqueRgbColorTest extends RgbColorTestCase<OpaqueRgbColor> {
     }
 
     @Test
+    public void testToString3HexDigits() {
+        this.toStringAndCheck(
+            RgbColor.fromRgb0(0x111111),
+            "#111"
+        );
+    }
+
+    @Test
+    public void testToString3HexDigits2() {
+        this.toStringAndCheck(
+            RgbColor.fromRgb0(0xeeeeee),
+            "#eee"
+        );
+    }
+
+    @Test
     public void testToStringWebColorBlack() {
         final WebColorName webColorName = WebColorName.BLACK;
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-color/issues/307
- RgbColor#toString and #text should return compact 3 or 4 hex digit when possible